### PR TITLE
Prepend 'fem *' command before 'clr tstamp' and 'clr evcnt' in command files

### DIFF
--- a/src/mclient/cmdfetcher.cpp
+++ b/src/mclient/cmdfetcher.cpp
@@ -798,6 +798,9 @@ int CmdFetcher_ParseCmdFile(CmdFetcher* cf) {
 
     // Always append as header clear event counter and timestamp. Only in case we are starting a data taking run
     if (strcmp(cf->cmd_file, "ped") != 0 && strcmp(cf->cmd_file, "start") != 0 && strcmp(cf->cmd_file, "runTCM") != 0) {
+        sprintf(cf->snd[ix], "fem *\n");
+        cf->cmd_cnt++;
+        ix++;
         sprintf(cf->snd[ix], "clr tstamp\n");
         cf->cmd_cnt++;
         ix++;


### PR DESCRIPTION
Trying to solve issue #11.

This is the simpliest solution in terms of coding. There should be a better solution, but it would requiere a deeper understanding of the mclient source code which I lack of.