### PR TITLE
Fix setup conda job

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: 3.12
-          miniforge-variant: Mambaforge
+          miniforge-variant: Miniforge3
           use-mamba: true
 
       - name: Install dependencies


### PR DESCRIPTION
The job 'Setup conda' failed because the setup-miniconda action is configured to use the Mambaforge variant, which is deprecated and resulted in a 404 error when attempting to fetch the installer. 

This PR changes the miniforge-variant input from Mambaforge to Miniforge3 in the setup-miniconda step, as Miniforge3 is the recommended replacement.